### PR TITLE
Minor typo (current -> active) in menus.md

### DIFF
--- a/docs/configuration/menus.md
+++ b/docs/configuration/menus.md
@@ -246,7 +246,7 @@ Some of the more commonly used 'tricks' are:
     first item in the loop.
   - `{% if loop.last %}last{% endif %}` - Output `last`, but only for the last
     item in the loop.
-  - `{% if item|current %}active{% endif %}` - Output `current`, but only if
+  - `{% if item|current %}active{% endif %}` - Output `active`, but only if
     we're on the page that the item links to.
   - `{% if item.title is defined %}title='{{ item.title|escape }}'{% endif %}`
     - Add a `title` attribute, but only if it's defined in our `.yml`-file, or


### PR DESCRIPTION
`{% if item|current %}active{% endif %}` doesn't output `'current'` as in docs, but `'active'`.